### PR TITLE
Modular sensor data - task controlled

### DIFF
--- a/src/MecGrowMancer.cpp
+++ b/src/MecGrowMancer.cpp
@@ -51,6 +51,8 @@ void setup() {
   scheduler.addTask(syncRTCWithNTP, NTP_SYNC_INTERVAL);
   scheduler.addTask(checkWiFiConnection, 60000);
 
+  scheduler.addTask(updateTemperatureAndPressure, SENSOR_UPDATE_TMPPRES_INT);
+
   setDebugLevel(DEBUG_VERBOSE);
 }
 

--- a/src/MecGrowMancer.h
+++ b/src/MecGrowMancer.h
@@ -12,19 +12,19 @@
 #include <Arduino.h>
 
 // Custom module headers
+#include "config.h"
 #include "lcd_display.h"
 #include "bmp280_sensor.h"
 #include "rtc_module.h"
 #include "serial_debug.h"
 #include "scheduler.h"
 #include "wifi_manager.h"
+#include "sensor_data.h"
 
 // Cooperative multitasking with configurable CPU yield
 // While not really x% (depends on other things happening in the loop) it reasonably helps with reduction for infrequent tasks.
 const uint8_t CPU_THROTTLE_PERCENTAGE = 5;  // 5% throttle
 const uint32_t LOOP_DELAY_MS = (100 * CPU_THROTTLE_PERCENTAGE) / 100;
 
-// The period between LCD updates for known metrics (for the "dashboard" idle mode)
-// in milliseconds.
-const unsigned long LCD_UPDATE_INTERVAL = 1000;
+
 

--- a/src/config.h
+++ b/src/config.h
@@ -30,9 +30,18 @@ char* getConfig(const char* key);
  * LDR - Light Level Measurement Section
  */
 #define LDR_INTERVAL 5000               // how often in ms, to do light measurements
-// LDR - Filtering. 
-#define LDR_FILTER_ALPHA 0.2            // how quickly to respond to change. Lower = smoother, but slower
-#define MAX_CHANGE 100                  // prevent spikes by capping maximum change (in filtered values) between readings
-#define DRASTIC_CHANGE_THRESHOLD 500    // what constitutes a drastic change? If raw vs filtered values exceed this = it's considered significant
+#define LDR_FILTER_ALPHA 0.2            // FILTERING: how quickly to respond to change. Lower = smoother, but slower
+#define MAX_CHANGE 100                  // FILTERING: prevent spikes by capping maximum change (in filtered values) between readings
+#define DRASTIC_CHANGE_THRESHOLD 500    // FILTERING: what constitutes a drastic change? If raw vs filtered values exceed this = it's considered significant
+
+/**
+ * LCD Section
+ */
+#define LCD_UPDATE_INTERVAL 1000   // LCD updates/redraws. Generally 1s is good (clock looks good, and data is fresh)
+
+/**
+ * Temperature and Pressure Section
+ */
+#define SENSOR_UPDATE_TMPPRES_INT 10000  // update interval for temperature and pressure sensors. Use discretion.
 
 #endif

--- a/src/sensor_data.cpp
+++ b/src/sensor_data.cpp
@@ -1,0 +1,19 @@
+/*
+ * MecGrowMancer - ESP32-based Homestead/Farm/Garden/Home/Garage Manager
+ * Copyright (C) 2024 Marlon van der Linde <marlonv@pm.me>
+ * License: GNU GPLv3 (see LICENSE/COPYING file for details)
+ * 
+ * This file deals with the updating (called from scheduler, usually) functions from inputs.
+ * It stores all 'last read' sensor data in the SensorData structure, and encapsulates it here.
+ */
+
+#include "sensor_data.h"
+#include "bmp280_sensor.h"
+
+SensorData g_sensorData = {0.0f, 0.0f};  // init with defaults.
+
+// Calls to the bmp280_sensor code.
+void updateTemperatureAndPressure() {
+  g_sensorData.temperature = readTemperature();
+  g_sensorData.pressure = readPressure();
+}

--- a/src/sensor_data.h
+++ b/src/sensor_data.h
@@ -1,0 +1,20 @@
+/*
+ * MecGrowMancer - ESP32-based Homestead/Farm/Garden/Home/Garage Manager
+ * Copyright (C) 2024 Marlon van der Linde <marlonv@pm.me>
+ * License: GNU GPLv3 (see LICENSE/COPYING file for details)
+ */
+
+#ifndef SENSOR_DATA_H
+#define SENSOR_DATA_H
+
+struct SensorData {
+  float temperature;
+  float pressure;
+};
+
+extern SensorData g_sensorData;
+
+void updateTemperatureAndPressure();
+
+
+#endif  // SENSOR_DATA_H


### PR DESCRIPTION
Modularise the (previously horrible) sensor readings from LCD logic. Now use a sensor_data structure to store the last read values, and thus:
- we can schedule updates when we please
- call lcd refreshes whenever we wants and gett the freshest(last) values>

Compiles/Builds.
Currently:
```
RAM:   [=         ]  13.9% (used 45620 bytes from 327680 bytes)
Flash:   [======    ]  60.0% (used 787065 bytes from 1310720 bytes)
```